### PR TITLE
angular-in-memory-web-api move

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2090,8 +2090,7 @@
     "angular-in-memory-web-api": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/angular-in-memory-web-api/-/angular-in-memory-web-api-0.11.0.tgz",
-      "integrity": "sha512-QV1qYHm+Zd+wrvlcPLnAcqqGpOmCN1EUj4rRuYHpek8+QqFFdxBNuPZOJCKvU7I97z5QSKHsdc6PNKlpUQr3UA==",
-      "dev": true
+      "integrity": "sha512-QV1qYHm+Zd+wrvlcPLnAcqqGpOmCN1EUj4rRuYHpek8+QqFFdxBNuPZOJCKvU7I97z5QSKHsdc6PNKlpUQr3UA=="
     },
     "ansi-colors": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "@angular/router": "~11.0.3",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
-    "zone.js": "~0.10.2"
+    "zone.js": "~0.10.2",
+    "angular-in-memory-web-api": "^0.11.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1100.3",
@@ -31,7 +32,6 @@
     "@angular/compiler-cli": "~11.0.3",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
-    "angular-in-memory-web-api": "^0.11.0",
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",


### PR DESCRIPTION
angular-in-memory-web-api moved to runtime dependencies for demos in stackblitz